### PR TITLE
fix: Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,19 @@ RUN npm i
 
 RUN npm run build
 
-FROM nginx:1.27.2-alpine
+FROM ubuntu:24.10
 
 LABEL service="insimodus"
+
+# Install Nginx
+RUN apt-get -y update\
+  && apt-get -y install nginx git curl --no-install-recommends\
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build-stage /workdir/dist/ /usr/share/nginx/html
 
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000/tcp
+
+CMD ["/usr/sbin/nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,15 +1,15 @@
 server {
     listen 3000 default_server;
     listen [::]:3000 default_server;
-    
+
     root /usr/share/nginx/html;
     index index.html index.htm;
 
     server_name _;
     location / {
-        try_files $uri /index.html;        
+        try_files $uri /index.html;
     }
-    
+
     location /up {
         return 200 'OK';
         add_header Content-Type text/plain;


### PR DESCRIPTION
Liebe Gruppe Insimodus

nach langem ausprobieren konnte ich die App nach AWS deployen.

Es scheint so als ob das offizielle nginx Image eine andere Standardkonfiguration besitzt als der manuell installierte von meinem Beispiel. Auf jeden Fall klappt das Deployment mit meinem Beispiel und eurem Code (siehe Dockerfile)

Natürlich wäre es eleganter direkt das offizielle nginx image zu nehmen. Wie man vorgehen könnte um dies genauer zu analysieren wäre folgendermassen:

1. Lokal ein manueller Nginx und der Offizielle Nginx als Container starten.
2. Von Beiden die Standardkonfig zum Host kopieren: `docker run --rm --entrypoint=cat nginx /etc/nginx/nginx.conf > /host/path/nginx.conf`
3. Prüfen was sich genau unterscheidet.

Auf jeden Fall habt ihr keine "Schuld", dass es nicht geklappt hat. Eigentlich sollte es auch mit dem offiziellen nginx image gehen.

Beste Grüsse
Lukas Hodel
